### PR TITLE
Add C Linkage API to CLI Functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,6 +534,7 @@ dependencies = [
  "katsuba-types",
  "katsuba-utils",
  "katsuba-wad",
+ "libc",
  "log",
  "mimalloc",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,33 +4,33 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.1"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -43,36 +43,37 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.0"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.0"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.1"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -83,23 +84,23 @@ checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-link",
 ]
 
 [[package]]
@@ -110,9 +111,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "binrw"
@@ -132,25 +133,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8ba42866ce5bced2645bfa15e97eef2c62d2bdb530510538de8dd3d04efff3c"
 dependencies = [
  "either",
- "owo-colors",
+ "owo-colors 3.5.0",
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -164,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.7.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79ad7fb2dd38f3dabd76b09c6a5a20c038fc0213ef1e9afd30eb777f120f019"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
  "serde",
@@ -174,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.13.1"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 
 [[package]]
 name = "byteorder"
@@ -186,21 +181,25 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.0.76"
+version = "1.2.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
+checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.31"
+version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
+checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -208,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.31"
+version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
+checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -220,100 +219,94 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "color-eyre"
-version = "0.6.2"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
 dependencies = [
  "backtrace",
  "eyre",
  "indenter",
  "once_cell",
- "owo-colors",
+ "owo-colors 4.2.3",
 ]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "colored"
-version = "2.0.4"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "is-terminal",
- "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "const-oid"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.9"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -321,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -343,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "enum-map"
@@ -364,24 +357,24 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "eyre"
-version = "0.6.8"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
  "indenter",
  "once_cell",
@@ -394,10 +387,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
+name = "find-msvc-tools"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "generic-array"
@@ -411,50 +404,50 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets 0.52.0",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "globset"
-version = "0.4.13"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
 dependencies = [
  "aho-corasick",
  "bstr",
- "fnv",
  "log",
- "regex",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -465,56 +458,36 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "indenter"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indoc"
-version = "2.0.5"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
-dependencies = [
- "hermit-abi",
- "io-lifetimes",
- "rustix 0.37.20",
- "windows-sys 0.48.0",
+ "rustversion",
 ]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "katsuba"
@@ -534,7 +507,6 @@ dependencies = [
  "katsuba-types",
  "katsuba-utils",
  "katsuba-wad",
- "libc",
  "log",
  "mimalloc",
  "serde",
@@ -548,7 +520,7 @@ name = "katsuba-bcd"
 version = "0.1.0"
 dependencies = [
  "binrw",
- "bitflags 2.9.0",
+ "bitflags",
  "katsuba-utils",
  "serde",
 ]
@@ -596,7 +568,7 @@ dependencies = [
 name = "katsuba-object-property"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
  "byteorder",
  "katsuba-bit-buf",
  "katsuba-types",
@@ -636,7 +608,7 @@ dependencies = [
 name = "katsuba-types"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
  "katsuba-utils",
  "serde",
  "serde_json",
@@ -666,49 +638,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "katsubac"
+version = "0.8.6"
+dependencies = [
+ "eyre",
+ "katsuba",
+ "katsuba-object-property",
+ "katsuba-types",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libdeflate-sys"
-version = "1.23.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413b667c8a795fcbe6287a75a8ce92b1dae928172c716fe95044cb2ec7877941"
+checksum = "23bd6304ebf75390d8a99b88bdf2a266f62647838140cb64af8e6702f6e3fddc"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "libdeflater"
-version = "1.23.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78376c917eec0550b9c56c858de50e1b7ebf303116487562e624e63ce51453a"
+checksum = "d5d4880e6d634d3d029d65fa016038e788cc728a17b782684726fb34ee140caf"
 dependencies = [
  "libdeflate-sys",
 ]
 
 [[package]]
 name = "libm"
-version = "0.2.7"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.35"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
 dependencies = [
  "cc",
  "libc",
@@ -716,71 +699,64 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmap2"
-version = "0.9.5"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "memoffset"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "mimalloc"
-version = "0.1.39"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa01922b5ea280a911e323e4d2fd24b7fe5cc4042e0d2cda3c40775cdc4bdc9c"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
 dependencies = [
  "libmimalloc-sys",
 ]
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
- "byteorder",
  "lazy_static",
  "libm",
  "num-integer",
@@ -793,19 +769,18 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.43"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -814,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.16"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
@@ -824,9 +799,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -834,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.1"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -848,10 +823,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "owo-colors"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "pem-rfc7468"
@@ -864,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
  "phf_shared",
@@ -874,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1181c94580fa345f50f19d738aaa39c0ed30a600d95cb2d3e23f94266f14fbf"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
  "rand",
@@ -884,22 +871,22 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92aacdc5f16768709a569e913f7451034034178b05bdc8acda226659a3dccc66"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
 ]
@@ -927,21 +914,24 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
@@ -991,7 +981,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1004,17 +994,23 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -1043,14 +1039,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.10",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1060,9 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1071,15 +1067,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rsa"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c75d7c5c6b673e58bf54d8544a9f432e3a925b0e80f7cd3602ab5c50c55519"
+checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
 dependencies = [
  "const-oid",
  "digest",
@@ -1098,42 +1094,34 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustix"
-version = "0.37.20"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "errno",
- "io-lifetimes",
  "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "rustix"
-version = "0.38.44"
+name = "rustversion"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.9.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
-]
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -1146,33 +1134,45 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1187,10 +1187,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "2.1.0"
+name = "shlex"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
  "rand_core",
@@ -1198,26 +1204,26 @@ dependencies = [
 
 [[package]]
 name = "simple_logger"
-version = "5.0.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c5dfa5e08767553704aa0ffd9d9794d527103c736aba9854773851fd7497eb"
+checksum = "291bee647ce7310b0ea721bfd7e0525517b4468eb7c7e15eb8bd774343179702"
 dependencies = [
  "colored",
  "log",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "siphasher"
-version = "0.3.10"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smartstring"
@@ -1233,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
@@ -1261,15 +1267,15 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1278,9 +1284,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1295,36 +1301,35 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tempfile"
-version = "3.17.1"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
- "cfg-if",
  "fastrand",
- "getrandom 0.3.1",
+ "getrandom 0.3.4",
  "once_cell",
- "rustix 0.38.44",
- "windows-sys 0.52.0",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1338,39 +1343,39 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unindent"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -1378,193 +1383,218 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
+name = "windows-link"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.33.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
- "bitflags 2.9.0",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.6.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"

--- a/src/katsuba-c/Cargo.toml
+++ b/src/katsuba-c/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "katsubac"
+version = "0.8.6"
+authors = ["Marcus S. <marcus.s@booleanbirch@users.noreply.github.com>"]
+description = "C API for calling CLI functions"
+license = "ISC"
+edition = "2021"
+
+[lib]
+name = "katsubac"
+crate-type = ["cdylib"]
+
+[dependencies.katsuba-object-property]
+path = "../katsuba-object-property"
+features = ["option-guessing", "serde"]
+
+[dependencies]
+katsuba = { path = "../katsuba" }
+katsuba-types = { path = "../katsuba-types" }
+
+eyre = "0.6"
+libc = "0.2"

--- a/src/katsuba-c/src/lib.rs
+++ b/src/katsuba-c/src/lib.rs
@@ -28,6 +28,8 @@ use katsuba_object_property::serde;
 
 use katsuba_types::{PropertyFlags, TypeList};
 
+/// C linkage function for calling the CLI command "katsuba bcd de",
+/// which calls the rust function [`katsuba::cmd::bcd::deserialize`]
 #[no_mangle]
 pub extern "C" fn bcd_deserialize(input: *const c_char, output: *const c_char) -> bool {
     let default_path = PathBuf::from(HYPHEN);
@@ -79,6 +81,8 @@ fn get_private_key_path_from_c(private_key_file: *const c_char) -> eyre::Result<
     }
 }
 
+/// C linkage function for calling the CLI command "katsuba cs arg",
+/// which calls the rust function [`katsuba::cmd::cs::arg`]
 #[no_mangle]
 pub extern "C" fn cs_arg(private_key_file: *const c_char) -> bool {
     let private_key = match get_private_key_path_from_c(private_key_file) {
@@ -89,6 +93,8 @@ pub extern "C" fn cs_arg(private_key_file: *const c_char) -> bool {
     rust_cs_arg(&private_key).is_ok()
 }
 
+/// C linkage function for calling the CLI command "katsuba cs decrypt",
+/// which calls the rust function [`katsuba::cmd::cs::decrypt`]
 #[no_mangle]
 pub extern "C" fn cs_decrypt(private_key_file: *const c_char, path: *const c_char, output: *const c_char) -> bool {
     let private_key = match get_private_key_path_from_c(private_key_file) {
@@ -118,7 +124,6 @@ pub extern "C" fn cs_decrypt(private_key_file: *const c_char, path: *const c_cha
 }
 
 /// The hash algorithm to apply. Duplicate of Algo enum.
-///
 /// This enum is accessible from C.
 #[repr(C)]
 #[allow(dead_code)]
@@ -138,6 +143,8 @@ impl From<&CAlgo> for Algo {
     }
 }
 
+/// C linkage function for calling the CLI command "katsuba hash",
+/// which calls the rust function [`katsuba::cmd::hash::hash`]
 #[no_mangle]
 pub extern "C" fn hash_c(input: *const c_char, algo: CAlgo) -> bool {
     let rust_input = if input.is_null() {
@@ -154,6 +161,8 @@ pub extern "C" fn hash_c(input: *const c_char, algo: CAlgo) -> bool {
     hash(&rust_input, rust_algo).is_ok()
 }
 
+/// C linkage function for calling the CLI command "katsuba nav de",
+/// which calls the rust function [`katsuba::cmd::nav::deserialize_nav`]
 #[no_mangle]
 pub extern "C" fn nav_deserialize(
     input: *const c_char,
@@ -187,6 +196,8 @@ pub extern "C" fn nav_deserialize(
     rust_nav_deserialize(io).is_ok()
 }
 
+/// C linkage function for calling the CLI command "katsuba nav de",
+/// which calls the rust function [`katsuba::cmd::nav::deserialize_zonenav`]
 #[no_mangle]
 pub extern "C" fn zonenav_deserialize(
     input: *const c_char,
@@ -243,6 +254,8 @@ fn get_type_lists_from_c(type_lists: *const *const c_char) -> eyre::Result<Arc<T
     }
 }
 
+/// C linkage function for calling the CLI command "katsuba op de",
+/// which calls the rust function [`katsuba::cmd::op::deserialize`]
 #[no_mangle]
 pub extern "C" fn op_deserialize(
     input: *const c_char,
@@ -300,6 +313,8 @@ pub extern "C" fn op_deserialize(
     rust_op_deserialize(io, type_list, options, ignore_unknown_types).is_ok()
 }
 
+/// C linkage function for calling the CLI command "katsuba op guess",
+/// which calls the rust function [`katsuba::cmd::op::guess::guess`]
 #[no_mangle]
 pub extern "C" fn op_guess(
     path: *const c_char,
@@ -336,6 +351,8 @@ pub extern "C" fn op_guess(
     guess::guess(options, type_list, rust_path, quiet).is_ok()
 }
 
+/// C linkage function for calling the CLI command "katsuba poi de",
+/// which calls the rust function [`katsuba::cmd::poi::deserialize`]
 #[no_mangle]
 pub extern "C" fn poi_deserialize(
     input: *const c_char,
@@ -369,6 +386,8 @@ pub extern "C" fn poi_deserialize(
     rust_poi_deserialize(io).is_ok()
 }
 
+/// C linkage function for calling the CLI command "katsuba wad pack",
+/// which calls the rust function [`katsuba::cmd::wad::wad_pack`]
 #[no_mangle]
 pub extern "C" fn wad_pack(
     input: *const c_char,
@@ -396,6 +415,8 @@ pub extern "C" fn wad_pack(
     rust_wad_pack(input_path, flags, output_path).is_ok()
 }
 
+/// C linkage function for calling the CLI command "katsuba wad unpack",
+/// which calls the rust function [`katsuba::cmd::wad::wad_unpack`]
 #[no_mangle]
 pub extern "C" fn wad_unpack(
     input: *const c_char,

--- a/src/katsuba-c/src/lib.rs
+++ b/src/katsuba-c/src/lib.rs
@@ -1,0 +1,423 @@
+use std::{
+    env::{self, VarError},
+    ffi::{CStr},
+    path::{PathBuf},
+    sync::{Arc},
+};
+
+use libc::{c_char};
+
+use katsuba::cli::{HYPHEN};
+use katsuba::cli::io::{InputsOutputs};
+use katsuba::cmd::bcd::{deserialize as rust_bcd_deserialize};
+use katsuba::cmd::cs::{KATSUBA_CLIENTSIG_PRIVATE_KEY, DEFAULT_OUTPUT_FILE, arg, decrypt};
+use katsuba::cmd::hash::{Algo, hash};
+use katsuba::cmd::nav::{deserialize_nav, deserialize_zonenav};
+use katsuba::cmd::op::{deserialize as rust_op_deserialize};
+use katsuba::cmd::op::guess;
+use katsuba::cmd::op::utils::{merge_type_lists};
+use katsuba::cmd::poi::{deserialize as rust_poi_deserialize};
+use katsuba::cmd::wad::{wad_pack, wad_unpack};
+use katsuba_object_property::serde;
+use katsuba_types::{PropertyFlags, TypeList};
+
+#[no_mangle]
+pub extern "C" fn bcd_deserialize(input: *const c_char, output: *const c_char) -> bool {
+    let default_path = PathBuf::from(HYPHEN);
+
+    let rust_input = if input.is_null() {
+        return false
+    } else {
+        match unsafe { CStr::from_ptr(input) }.to_str() {
+            Ok(rust_str) => rust_str.to_owned(),
+            Err(_) => return false,
+        }
+    };
+
+    let rust_output = if output.is_null() {
+        default_path
+    } else {
+        match unsafe { CStr::from_ptr(output) }.to_str() {
+            Ok(rust_str) => PathBuf::from(rust_str),
+            Err(_) => default_path,
+        }
+    };
+
+    let io = InputsOutputs {
+        input: rust_input,
+        output: rust_output,
+    };
+
+    rust_bcd_deserialize(io).is_ok()
+}
+
+fn get_private_key_path_from_c(private_key_file: *const c_char) -> eyre::Result<PathBuf, VarError> {
+    let private_key = if !private_key_file.is_null() {
+        match unsafe { CStr::from_ptr(private_key_file) }.to_str() {
+            Ok(rust_str) => rust_str,
+            Err(_) => "",
+        }
+    } else {
+        ""
+    };
+
+    // No private key file was given, try the environment variable instead
+    if private_key == "" {
+        match env::var(KATSUBA_CLIENTSIG_PRIVATE_KEY) {
+            Ok(value) => Ok(PathBuf::from(value)),
+            Err(error) => Err(error), // No value found for environment variable
+        }
+    } else {
+        Ok(PathBuf::from(private_key))
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn cs_arg(private_key_file: *const c_char) -> bool {
+    let private_key = match get_private_key_path_from_c(private_key_file) {
+        Ok(key) => key,
+        Err(_) => return false,
+    };
+
+    arg(&private_key).is_ok()
+}
+
+#[no_mangle]
+pub extern "C" fn cs_decrypt(private_key_file: *const c_char, path: *const c_char, output: *const c_char) -> bool {
+    let private_key = match get_private_key_path_from_c(private_key_file) {
+        Ok(key) => key,
+        Err(_) => return false,
+    };
+
+    let rust_path = if path.is_null() {
+        return false
+    } else {
+        match unsafe { CStr::from_ptr(path) }.to_str() {
+            Ok(rust_str) => PathBuf::from(rust_str),
+            Err(_) => return false,
+        }
+    };
+
+    let rust_output = if output.is_null() {
+        PathBuf::from(DEFAULT_OUTPUT_FILE)
+    } else {
+        match unsafe { CStr::from_ptr(output) }.to_str() {
+            Ok(rust_str) => PathBuf::from(rust_str),
+            Err(_) => PathBuf::from(DEFAULT_OUTPUT_FILE),
+        }
+    };
+
+    decrypt(&private_key, rust_path, rust_output).is_ok()
+}
+
+/// The hash algorithm to apply. Duplicate of Algo enum.
+///
+/// This enum is accessible from C.
+#[repr(C)]
+#[allow(dead_code)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum CAlgo {
+    /// The KingsIsle string ID algorithm.
+    StringId,
+    /// The DJB2 algorithm.
+    Djb2,
+}
+impl From<&CAlgo> for Algo {
+    fn from(algo: &CAlgo) -> Self {
+        match algo {
+            CAlgo::StringId => Algo::StringId,
+            CAlgo::Djb2 => Algo::Djb2,
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn hash_c(input: *const c_char, algo: CAlgo) -> bool {
+    let rust_input = if input.is_null() {
+        return false
+    } else {
+        match unsafe { CStr::from_ptr(input) }.to_str() {
+            Ok(rust_str) => rust_str.to_owned(),
+            Err(_) => return false,
+        }
+    };
+
+    let rust_algo = Algo::from(&algo);
+
+    hash(&rust_input, rust_algo).is_ok()
+}
+
+#[no_mangle]
+pub extern "C" fn nav_deserialize(
+    input: *const c_char,
+    output: *const c_char,
+) -> bool {
+    let default_path = PathBuf::from(HYPHEN);
+
+    let rust_input = if input.is_null() {
+        return false
+    } else {
+        match unsafe { CStr::from_ptr(input) }.to_str() {
+            Ok(rust_str) => rust_str.to_owned(),
+            Err(_) => return false,
+        }
+    };
+
+    let rust_output = if output.is_null() {
+        default_path
+    } else {
+        match unsafe { CStr::from_ptr(output) }.to_str() {
+            Ok(rust_str) => PathBuf::from(rust_str),
+            Err(_) => default_path,
+        }
+    };
+
+    let io = InputsOutputs {
+        input: rust_input,
+        output: rust_output,
+    };
+
+    deserialize_nav(io).is_ok()
+}
+
+#[no_mangle]
+pub extern "C" fn zonenav_deserialize(
+    input: *const c_char,
+    output: *const c_char,
+) -> bool {
+    let default_path = PathBuf::from(HYPHEN);
+
+    let rust_input = if input.is_null() {
+        return false
+    } else {
+        match unsafe { CStr::from_ptr(input) }.to_str() {
+            Ok(rust_str) => rust_str.to_owned(),
+            Err(_) => return false,
+        }
+    };
+
+    let rust_output = if output.is_null() {
+        default_path
+    } else {
+        match unsafe { CStr::from_ptr(output) }.to_str() {
+            Ok(rust_str) => PathBuf::from(rust_str),
+            Err(_) => default_path,
+        }
+    };
+
+    let io = InputsOutputs {
+        input: rust_input,
+        output: rust_output,
+    };
+
+    deserialize_zonenav(io).is_ok()
+}
+
+fn get_type_lists_from_c(type_lists: *const *const c_char) -> eyre::Result<Arc<TypeList>> {
+    let mut type_list_paths = Vec::new();
+    let mut i = 0;
+    loop {
+        let current_type_list = unsafe { *type_lists.add(i) };
+        if current_type_list.is_null() {
+            break // Null pointer indicates end of array
+        }
+
+        match unsafe { CStr::from_ptr(current_type_list) }.to_str() {
+            Ok(rust_str) => type_list_paths.push(PathBuf::from(rust_str)),
+            Err(_) => continue,
+        };
+
+        i += 1;
+    }
+
+    match merge_type_lists(type_list_paths) {
+        Ok(combined_type_list) => Ok(Arc::new(combined_type_list)),
+        Err(report) => Err(report),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn op_deserialize(
+    input: *const c_char,
+    output: *const c_char,
+    type_lists: *const *const c_char,
+    flags: u32,
+    mask: u32,
+    shallow: bool,
+    manual_compression: bool,
+    djb2_only: bool,
+    ignore_unknown_types: bool,
+) -> bool {
+    let default_path = PathBuf::from(HYPHEN);
+
+    if input.is_null() || type_lists.is_null() {
+        return false
+    }
+
+    // Create the InputsOutputs
+    let rust_input = match unsafe { CStr::from_ptr(input) }.to_str() {
+        Ok(rust_str) => rust_str.to_owned(),
+        Err(_) => return false,
+    };
+
+    let rust_output = if output.is_null() {
+        default_path
+    } else {
+        match unsafe { CStr::from_ptr(output) }.to_str() {
+            Ok(rust_str) => PathBuf::from(rust_str),
+            Err(_) => default_path,
+        }
+    };
+
+    let io = InputsOutputs {
+        input: rust_input,
+        output: rust_output,
+    };
+
+    // Create the type_list
+    let type_list = match get_type_lists_from_c(type_lists) {
+        Ok(list) => list,
+        Err(_) => return false,
+    };
+
+    // Set the options
+    let options = serde::SerializerOptions {
+        flags: serde::SerializerFlags::from_bits_truncate(flags),
+        property_mask: PropertyFlags::from_bits_truncate(mask),
+        shallow: shallow,
+        manual_compression: manual_compression,
+        djb2_only: djb2_only,
+        ..Default::default()
+    };
+
+    rust_op_deserialize(io, type_list, options, ignore_unknown_types).is_ok()
+}
+
+#[no_mangle]
+pub extern "C" fn op_guess(
+    path: *const c_char,
+    type_lists: *const *const c_char,
+    flags: u32,
+    mask: u32,
+    shallow: bool,
+    manual_compression: bool,
+    djb2_only: bool,
+    quiet: bool,
+) -> bool {
+
+    // Set the options
+    let options = serde::SerializerOptions {
+        flags: serde::SerializerFlags::from_bits_truncate(flags),
+        property_mask: PropertyFlags::from_bits_truncate(mask),
+        shallow: shallow,
+        manual_compression: manual_compression,
+        djb2_only: djb2_only,
+        ..Default::default()
+    };
+
+    // Create the type_list
+    let type_list = match get_type_lists_from_c(type_lists) {
+        Ok(list) => list,
+        Err(_) => return false,
+    };
+
+    let rust_path = match unsafe { CStr::from_ptr(path) }.to_str() {
+        Ok(rust_str) => PathBuf::from(rust_str),
+        Err(_) => return false,
+    };
+
+    guess::guess(options, type_list, rust_path, quiet).is_ok()
+}
+
+#[no_mangle]
+pub extern "C" fn poi_deserialize(
+    input: *const c_char,
+    output: *const c_char,
+) -> bool {
+    let default_path = PathBuf::from(HYPHEN);
+
+    let rust_input = if input.is_null() {
+        return false
+    } else {
+        match unsafe { CStr::from_ptr(input) }.to_str() {
+            Ok(rust_str) => rust_str.to_owned(),
+            Err(_) => return false,
+        }
+    };
+
+    let rust_output = if output.is_null() {
+        default_path
+    } else {
+        match unsafe { CStr::from_ptr(output) }.to_str() {
+            Ok(rust_str) => PathBuf::from(rust_str),
+            Err(_) => default_path,
+        }
+    };
+
+    let io = InputsOutputs {
+        input: rust_input,
+        output: rust_output,
+    };
+
+    rust_poi_deserialize(io).is_ok()
+}
+
+#[no_mangle]
+pub extern "C" fn wad_pack_c(
+    input: *const c_char,
+    flags: u8,
+    output: *const c_char,
+) -> bool {
+    let input_path = if input.is_null() {
+        return false
+    } else {
+        match unsafe { CStr::from_ptr(input) }.to_str() {
+            Ok(rust_str) => PathBuf::from(rust_str),
+            Err(_) => return false,
+        }
+    };
+
+    let output_path = if output.is_null() {
+        None
+    } else {
+        match unsafe { CStr::from_ptr(output) }.to_str() {
+            Ok(rust_str) => Some(PathBuf::from(rust_str)),
+            Err(_) => None,
+        }
+    };
+
+    wad_pack(input_path, flags, output_path).is_ok()
+}
+
+#[no_mangle]
+pub extern "C" fn wad_unpack_c(
+    input: *const c_char,
+    output: *const c_char,
+) -> bool {
+    let rust_input = if input.is_null() {
+        return false
+    } else {
+        match unsafe { CStr::from_ptr(input) }.to_str() {
+            Ok(rust_str) => rust_str.to_owned(),
+            Err(_) => return false,
+        }
+    };
+
+    let default_path = PathBuf::from(HYPHEN);
+
+    let rust_output = if output.is_null() {
+        default_path
+    } else {
+        match unsafe { CStr::from_ptr(output) }.to_str() {
+            Ok(rust_str) => PathBuf::from(rust_str),
+            Err(_) => default_path,
+        }
+    };
+
+    let io = InputsOutputs {
+        input: rust_input,
+        output: rust_output,
+    };
+
+    wad_unpack(io).is_ok()
+}

--- a/src/katsuba-c/src/lib.rs
+++ b/src/katsuba-c/src/lib.rs
@@ -7,18 +7,25 @@ use std::{
 
 use libc::{c_char};
 
-use katsuba::cli::{HYPHEN};
-use katsuba::cli::io::{InputsOutputs};
-use katsuba::cmd::bcd::{deserialize as rust_bcd_deserialize};
-use katsuba::cmd::cs::{KATSUBA_CLIENTSIG_PRIVATE_KEY, DEFAULT_OUTPUT_FILE, arg, decrypt};
-use katsuba::cmd::hash::{Algo, hash};
-use katsuba::cmd::nav::{deserialize_nav, deserialize_zonenav};
-use katsuba::cmd::op::{deserialize as rust_op_deserialize};
-use katsuba::cmd::op::guess;
-use katsuba::cmd::op::utils::{merge_type_lists};
-use katsuba::cmd::poi::{deserialize as rust_poi_deserialize};
-use katsuba::cmd::wad::{wad_pack, wad_unpack};
+use katsuba::cli::{
+    HYPHEN,
+    io::{InputsOutputs},
+};
+
+use katsuba::cmd::{
+    bcd::{deserialize as rust_bcd_deserialize},
+    cs::{KATSUBA_CLIENTSIG_PRIVATE_KEY, DEFAULT_OUTPUT_FILE, arg as rust_cs_arg, decrypt as rust_cs_decrypt},
+    hash::{Algo, hash},
+    nav::{deserialize_nav as rust_nav_deserialize, deserialize_zonenav as rust_zonenav_deserialize},
+    op::{deserialize as rust_op_deserialize},
+    op::guess,
+    op::utils::{merge_type_lists},
+    poi::{deserialize as rust_poi_deserialize},
+    wad::{wad_pack as rust_wad_pack, wad_unpack as rust_wad_unpack},
+};
+
 use katsuba_object_property::serde;
+
 use katsuba_types::{PropertyFlags, TypeList};
 
 #[no_mangle]
@@ -79,7 +86,7 @@ pub extern "C" fn cs_arg(private_key_file: *const c_char) -> bool {
         Err(_) => return false,
     };
 
-    arg(&private_key).is_ok()
+    rust_cs_arg(&private_key).is_ok()
 }
 
 #[no_mangle]
@@ -107,7 +114,7 @@ pub extern "C" fn cs_decrypt(private_key_file: *const c_char, path: *const c_cha
         }
     };
 
-    decrypt(&private_key, rust_path, rust_output).is_ok()
+    rust_cs_decrypt(&private_key, rust_path, rust_output).is_ok()
 }
 
 /// The hash algorithm to apply. Duplicate of Algo enum.
@@ -177,7 +184,7 @@ pub extern "C" fn nav_deserialize(
         output: rust_output,
     };
 
-    deserialize_nav(io).is_ok()
+    rust_nav_deserialize(io).is_ok()
 }
 
 #[no_mangle]
@@ -210,7 +217,7 @@ pub extern "C" fn zonenav_deserialize(
         output: rust_output,
     };
 
-    deserialize_zonenav(io).is_ok()
+    rust_zonenav_deserialize(io).is_ok()
 }
 
 fn get_type_lists_from_c(type_lists: *const *const c_char) -> eyre::Result<Arc<TypeList>> {
@@ -363,7 +370,7 @@ pub extern "C" fn poi_deserialize(
 }
 
 #[no_mangle]
-pub extern "C" fn wad_pack_c(
+pub extern "C" fn wad_pack(
     input: *const c_char,
     flags: u8,
     output: *const c_char,
@@ -386,11 +393,11 @@ pub extern "C" fn wad_pack_c(
         }
     };
 
-    wad_pack(input_path, flags, output_path).is_ok()
+    rust_wad_pack(input_path, flags, output_path).is_ok()
 }
 
 #[no_mangle]
-pub extern "C" fn wad_unpack_c(
+pub extern "C" fn wad_unpack(
     input: *const c_char,
     output: *const c_char,
 ) -> bool {
@@ -419,5 +426,5 @@ pub extern "C" fn wad_unpack_c(
         output: rust_output,
     };
 
-    wad_unpack(io).is_ok()
+    rust_wad_unpack(io).is_ok()
 }

--- a/src/katsuba/Cargo.toml
+++ b/src/katsuba/Cargo.toml
@@ -25,7 +25,6 @@ color-eyre = { version = "0.6", default-features = false }
 enum-map = "2.7"
 eyre = "0.6"
 glob = "0.3"
-libc = "0.2"
 log = { workspace = true }
 mimalloc = "*"
 serde = { workspace = true }

--- a/src/katsuba/Cargo.toml
+++ b/src/katsuba/Cargo.toml
@@ -25,6 +25,7 @@ color-eyre = { version = "0.6", default-features = false }
 enum-map = "2.7"
 eyre = "0.6"
 glob = "0.3"
+libc = "0.2"
 log = { workspace = true }
 mimalloc = "*"
 serde = { workspace = true }

--- a/src/katsuba/src/cli.rs
+++ b/src/katsuba/src/cli.rs
@@ -12,6 +12,8 @@ pub use io::*;
 mod processor;
 pub use processor::*;
 
+pub const HYPHEN: &str = "-";
+
 /// The CLI interface for the Katsuba application.
 #[derive(Debug, Parser)]
 #[clap(author, version, about, long_about = None)]

--- a/src/katsuba/src/cli.rs
+++ b/src/katsuba/src/cli.rs
@@ -6,7 +6,7 @@ mod args;
 
 pub mod helpers;
 
-mod io;
+pub mod io;
 pub use io::*;
 
 mod processor;

--- a/src/katsuba/src/cli/io.rs
+++ b/src/katsuba/src/cli/io.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clap::Args;
 use glob::glob;
 
-const HYPHEN: &str = "-";
+use crate::cli::HYPHEN;
 
 /// An input source to [`InputsOutputs`] machinery.
 #[derive(Clone, Debug)]
@@ -48,7 +48,7 @@ pub struct InputsOutputs {
     /// Note however that when a glob pattern matches more than one
     /// file, an explicit output directory for all the result files
     /// needs to be specified with the output option.
-    input: String,
+    pub input: String,
 
     /// An optional output source for the processed outputs.
     ///
@@ -58,7 +58,7 @@ pub struct InputsOutputs {
     /// input was a single file too), or a path to a directory
     /// where output files will be created for each input file.
     #[clap(short, default_value = HYPHEN)]
-    output: PathBuf,
+    pub output: PathBuf,
 }
 
 impl InputsOutputs {

--- a/src/katsuba/src/cmd/bcd.rs
+++ b/src/katsuba/src/cmd/bcd.rs
@@ -1,8 +1,15 @@
+use std::{
+    ffi::{CStr},
+    path::{PathBuf},
+};
+
+use libc::{c_char};
+
 use clap::{Args, Subcommand};
 use katsuba_bcd::Bcd as BcdFile;
 
 use super::Command;
-use crate::cli::{helpers, Bias, InputsOutputs, Processor};
+use crate::cli::{helpers, Bias, InputsOutputs, Processor, HYPHEN};
 
 /// Subcommand for working with BCD data.
 #[derive(Debug, Args)]
@@ -33,4 +40,34 @@ fn deserialize(args: InputsOutputs) -> eyre::Result<()> {
         .read_with(|r, _| BcdFile::parse(r).map_err(Into::into))
         .write_with(helpers::write_as_json)
         .process(inputs, outputs)
+}
+
+#[no_mangle]
+pub extern "C" fn bcd_deserialize(input: *const c_char, output: *const c_char) -> bool {
+    let default_path = PathBuf::from(HYPHEN);
+
+    let rust_input = if input.is_null() {
+        return false
+    } else {
+        match unsafe { CStr::from_ptr(input) }.to_str() {
+            Ok(rust_str) => rust_str.to_owned(),
+            Err(_) => return false,
+        }
+    };
+
+    let rust_output = if output.is_null() {
+        default_path
+    } else {
+        match unsafe { CStr::from_ptr(output) }.to_str() {
+            Ok(rust_str) => PathBuf::from(rust_str),
+            Err(_) => default_path,
+        }
+    };
+
+    let io = InputsOutputs {
+        input: rust_input,
+        output: rust_output,
+    };
+
+    deserialize(io).is_ok()
 }

--- a/src/katsuba/src/cmd/bcd.rs
+++ b/src/katsuba/src/cmd/bcd.rs
@@ -21,12 +21,16 @@ impl Command for Bcd {
     fn handle(self) -> eyre::Result<()> {
         match self.command {
             BcdCommand::De(args) => {
-                let (inputs, outputs) = args.evaluate("de.json")?;
-                Processor::new(Bias::Current)?
-                    .read_with(|r, _| BcdFile::parse(r).map_err(Into::into))
-                    .write_with(helpers::write_as_json)
-                    .process(inputs, outputs)
+                deserialize(args)
             }
         }
     }
+}
+
+fn deserialize(args: InputsOutputs) -> eyre::Result<()> {
+    let (inputs, outputs) = args.evaluate("de.json")?;
+    Processor::new(Bias::Current)?
+        .read_with(|r, _| BcdFile::parse(r).map_err(Into::into))
+        .write_with(helpers::write_as_json)
+        .process(inputs, outputs)
 }

--- a/src/katsuba/src/cmd/bcd.rs
+++ b/src/katsuba/src/cmd/bcd.rs
@@ -1,15 +1,8 @@
-use std::{
-    ffi::{CStr},
-    path::{PathBuf},
-};
-
-use libc::{c_char};
-
 use clap::{Args, Subcommand};
 use katsuba_bcd::Bcd as BcdFile;
 
 use super::Command;
-use crate::cli::{helpers, Bias, InputsOutputs, Processor, HYPHEN};
+use crate::cli::{helpers, Bias, InputsOutputs, Processor};
 
 /// Subcommand for working with BCD data.
 #[derive(Debug, Args)]
@@ -34,40 +27,10 @@ impl Command for Bcd {
     }
 }
 
-fn deserialize(args: InputsOutputs) -> eyre::Result<()> {
+pub fn deserialize(args: InputsOutputs) -> eyre::Result<()> {
     let (inputs, outputs) = args.evaluate("de.json")?;
     Processor::new(Bias::Current)?
         .read_with(|r, _| BcdFile::parse(r).map_err(Into::into))
         .write_with(helpers::write_as_json)
         .process(inputs, outputs)
-}
-
-#[no_mangle]
-pub extern "C" fn bcd_deserialize(input: *const c_char, output: *const c_char) -> bool {
-    let default_path = PathBuf::from(HYPHEN);
-
-    let rust_input = if input.is_null() {
-        return false
-    } else {
-        match unsafe { CStr::from_ptr(input) }.to_str() {
-            Ok(rust_str) => rust_str.to_owned(),
-            Err(_) => return false,
-        }
-    };
-
-    let rust_output = if output.is_null() {
-        default_path
-    } else {
-        match unsafe { CStr::from_ptr(output) }.to_str() {
-            Ok(rust_str) => PathBuf::from(rust_str),
-            Err(_) => default_path,
-        }
-    };
-
-    let io = InputsOutputs {
-        input: rust_input,
-        output: rust_output,
-    };
-
-    deserialize(io).is_ok()
 }

--- a/src/katsuba/src/cmd/cs.rs
+++ b/src/katsuba/src/cmd/cs.rs
@@ -1,11 +1,4 @@
-use std::{
-    env::{self, VarError},
-    ffi::CStr,
-    fs,
-    path::PathBuf,
-};
-
-use libc::{c_char};
+use std::{fs, path::PathBuf};
 
 use clap::{Args, Subcommand};
 use eyre::Context;
@@ -79,14 +72,14 @@ fn get_private_key(private_key_file: &PathBuf) -> eyre::Result<PrivateKey> {
     PrivateKey::new(&private_key).context("failed to parse given private key")
 }
 
-fn arg(private_key_file: &PathBuf) -> eyre::Result<()> {
+pub fn arg(private_key_file: &PathBuf) -> eyre::Result<()> {
     let private_key = get_private_key(&private_key_file)?;
     let arg = private_key.make_access_key();
     println!("{arg}");
     Ok(())
 }
 
-fn decrypt(private_key_file: &PathBuf, path: PathBuf, output: PathBuf) -> eyre::Result<()> {
+pub fn decrypt(private_key_file: &PathBuf, path: PathBuf, output: PathBuf) -> eyre::Result<()> {
     let private_key = get_private_key(&private_key_file)?;
 
     let signature = fs::read(&path)
@@ -98,63 +91,4 @@ fn decrypt(private_key_file: &PathBuf, path: PathBuf, output: PathBuf) -> eyre::
 
     fs::write(output, decrypted_signature)?;
     Ok(())
-}
-
-fn get_private_key_path_from_c(private_key_file: *const c_char) -> eyre::Result<PathBuf, VarError> {
-    let private_key = if !private_key_file.is_null() {
-        match unsafe { CStr::from_ptr(private_key_file) }.to_str() {
-            Ok(rust_str) => rust_str,
-            Err(_) => "",
-        }
-    } else {
-        ""
-    };
-
-    // No private key file was given, try the environment variable instead
-    if private_key == "" {
-        match env::var(KATSUBA_CLIENTSIG_PRIVATE_KEY) {
-            Ok(value) => Ok(PathBuf::from(value)),
-            Err(error) => Err(error), // No value found for environment variable
-        }
-    } else {
-        Ok(PathBuf::from(private_key))
-    }
-}
-
-#[no_mangle]
-pub extern "C" fn cs_arg(private_key_file: *const c_char) -> bool {
-    let private_key = match get_private_key_path_from_c(private_key_file) {
-        Ok(key) => key,
-        Err(_) => return false,
-    };
-
-    arg(&private_key).is_ok()
-}
-
-#[no_mangle]
-pub extern "C" fn cs_decrypt(private_key_file: *const c_char, path: *const c_char, output: *const c_char) -> bool {
-    let private_key = match get_private_key_path_from_c(private_key_file) {
-        Ok(key) => key,
-        Err(_) => return false,
-    };
-
-    let rust_path = if path.is_null() {
-        return false
-    } else {
-        match unsafe { CStr::from_ptr(path) }.to_str() {
-            Ok(rust_str) => PathBuf::from(rust_str),
-            Err(_) => return false,
-        }
-    };
-
-    let rust_output = if output.is_null() {
-        PathBuf::from(DEFAULT_OUTPUT_FILE)
-    } else {
-        match unsafe { CStr::from_ptr(output) }.to_str() {
-            Ok(rust_str) => PathBuf::from(rust_str),
-            Err(_) => PathBuf::from(DEFAULT_OUTPUT_FILE),
-        }
-    };
-
-    decrypt(&private_key, rust_path, rust_output).is_ok()
 }

--- a/src/katsuba/src/cmd/cs.rs
+++ b/src/katsuba/src/cmd/cs.rs
@@ -6,6 +6,9 @@ use katsuba_client_sig::PrivateKey;
 
 use super::Command;
 
+pub const KATSUBA_CLIENTSIG_PRIVATE_KEY: &str = "KATSUBA_CLIENTSIG_PRIVATE_KEY";
+pub const DEFAULT_OUTPUT_FILE: &str = "ClientSig.dec.bin";
+
 /// Subcommand for working with Client Signatures.
 #[derive(Debug, Args)]
 pub struct ClientSig {
@@ -20,7 +23,7 @@ pub struct ClientSig {
     ///
     /// If no argument is provided, Katsuba will try to find a file path
     /// under the `KATSUBA_CLIENTSIG_PRIVATE_KEY` environment variable.
-    #[clap(short, long, env = "KATSUBA_CLIENTSIG_PRIVATE_KEY")]
+    #[clap(short, long, env = KATSUBA_CLIENTSIG_PRIVATE_KEY)]
     private_key: PathBuf,
 }
 
@@ -40,7 +43,7 @@ enum ClientSigCommand {
         /// Optional path to an output file for the decrypted signature.
         ///
         /// Defaults to `ClientSig.dec.bin` in the working directory.
-        #[clap(short, long, default_value = "ClientSig.dec.bin")]
+        #[clap(short, long, default_value = DEFAULT_OUTPUT_FILE)]
         output: PathBuf,
     },
 }

--- a/src/katsuba/src/cmd/hash.rs
+++ b/src/katsuba/src/cmd/hash.rs
@@ -26,13 +26,17 @@ enum Algo {
 
 impl Command for Hash {
     fn handle(self) -> eyre::Result<()> {
-        let input = self.input.as_bytes();
-        let hash = match self.algo {
-            Algo::StringId => string_id(input),
-            Algo::Djb2 => djb2(input),
-        };
-
-        println!("{hash}");
-        Ok(())
+        hash(&self.input, self.algo)
     }
+}
+
+fn hash(input: &String, algo: Algo) -> eyre::Result<()> {
+    let input = input.as_bytes();
+    let hash = match algo {
+        Algo::StringId => string_id(input),
+        Algo::Djb2 => djb2(input),
+    };
+
+    println!("{hash}");
+    Ok(())
 }

--- a/src/katsuba/src/cmd/hash.rs
+++ b/src/katsuba/src/cmd/hash.rs
@@ -1,9 +1,3 @@
-use std::{
-    ffi::{CStr},
-};
-
-use libc::{c_char};
-
 use clap::{Args, ValueEnum};
 
 use katsuba_utils::hash::*;
@@ -23,7 +17,7 @@ pub struct Hash {
 
 /// The hash algorithm to apply.
 #[derive(Clone, Debug, ValueEnum)]
-enum Algo {
+pub enum Algo {
     /// The KingsIsle string ID algorithm.
     StringId,
     /// The DJB2 algorithm.
@@ -36,7 +30,7 @@ impl Command for Hash {
     }
 }
 
-fn hash(input: &String, algo: Algo) -> eyre::Result<()> {
+pub fn hash(input: &String, algo: Algo) -> eyre::Result<()> {
     let input = input.as_bytes();
     let hash = match algo {
         Algo::StringId => string_id(input),
@@ -45,41 +39,4 @@ fn hash(input: &String, algo: Algo) -> eyre::Result<()> {
 
     println!("{hash}");
     Ok(())
-}
-
-/// The hash algorithm to apply. Duplicate of Algo enum.
-///
-/// This enum is accessible from C.
-#[repr(C)]
-#[allow(dead_code)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum CAlgo {
-    /// The KingsIsle string ID algorithm.
-    StringId,
-    /// The DJB2 algorithm.
-    Djb2,
-}
-impl From<&CAlgo> for Algo {
-    fn from(algo: &CAlgo) -> Self {
-        match algo {
-            CAlgo::StringId => Algo::StringId,
-            CAlgo::Djb2 => Algo::Djb2,
-        }
-    }
-}
-
-#[no_mangle]
-pub extern "C" fn hash_c(input: *const c_char, algo: CAlgo) -> bool {
-    let rust_input = if input.is_null() {
-        return false
-    } else {
-        match unsafe { CStr::from_ptr(input) }.to_str() {
-            Ok(rust_str) => rust_str.to_owned(),
-            Err(_) => return false,
-        }
-    };
-
-    let rust_algo = Algo::from(&algo);
-
-    hash(&rust_input, rust_algo).is_ok()
 }

--- a/src/katsuba/src/cmd/hash.rs
+++ b/src/katsuba/src/cmd/hash.rs
@@ -1,3 +1,9 @@
+use std::{
+    ffi::{CStr},
+};
+
+use libc::{c_char};
+
 use clap::{Args, ValueEnum};
 
 use katsuba_utils::hash::*;
@@ -39,4 +45,41 @@ fn hash(input: &String, algo: Algo) -> eyre::Result<()> {
 
     println!("{hash}");
     Ok(())
+}
+
+/// The hash algorithm to apply. Duplicate of Algo enum.
+///
+/// This enum is accessible from C.
+#[repr(C)]
+#[allow(dead_code)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum CAlgo {
+    /// The KingsIsle string ID algorithm.
+    StringId,
+    /// The DJB2 algorithm.
+    Djb2,
+}
+impl From<&CAlgo> for Algo {
+    fn from(algo: &CAlgo) -> Self {
+        match algo {
+            CAlgo::StringId => Algo::StringId,
+            CAlgo::Djb2 => Algo::Djb2,
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn hash_c(input: *const c_char, algo: CAlgo) -> bool {
+    let rust_input = if input.is_null() {
+        return false
+    } else {
+        match unsafe { CStr::from_ptr(input) }.to_str() {
+            Ok(rust_str) => rust_str.to_owned(),
+            Err(_) => return false,
+        }
+    };
+
+    let rust_algo = Algo::from(&algo);
+
+    hash(&rust_input, rust_algo).is_ok()
 }

--- a/src/katsuba/src/cmd/nav.rs
+++ b/src/katsuba/src/cmd/nav.rs
@@ -34,21 +34,27 @@ impl Command for Nav {
     fn handle(self) -> eyre::Result<()> {
         match self.command {
             NavCommand::De(args) => {
-                let (inputs, outputs) = args.evaluate("de.json")?;
-                let processor = Processor::new(Bias::Current)?;
-
                 match self.file_type {
-                    FileType::Nav => processor
-                        .read_with(|r, _| NavigationGraph::parse(r).map_err(Into::into))
-                        .write_with(helpers::write_as_json)
-                        .process(inputs, outputs),
-
-                    FileType::ZoneNav => processor
-                        .read_with(|r, _| ZoneNavigationGraph::parse(r).map_err(Into::into))
-                        .write_with(helpers::write_as_json)
-                        .process(inputs, outputs),
+                    FileType::Nav => deserialize_nav(args),
+                    FileType::ZoneNav => deserialize_zonenav(args),
                 }
             }
         }
     }
+}
+
+fn deserialize_nav(args: InputsOutputs) -> eyre::Result<()> {
+    let (inputs, outputs) = args.evaluate("de.json")?;
+    Processor::new(Bias::Current)?
+        .read_with(|r, _| NavigationGraph::parse(r).map_err(Into::into))
+        .write_with(helpers::write_as_json)
+        .process(inputs, outputs)
+}
+
+fn deserialize_zonenav(args: InputsOutputs) -> eyre::Result<()> {
+    let (inputs, outputs) = args.evaluate("de.json")?;
+    Processor::new(Bias::Current)?
+        .read_with(|r, _| ZoneNavigationGraph::parse(r).map_err(Into::into))
+        .write_with(helpers::write_as_json)
+        .process(inputs, outputs)
 }

--- a/src/katsuba/src/cmd/nav.rs
+++ b/src/katsuba/src/cmd/nav.rs
@@ -1,15 +1,8 @@
-use std::{
-    ffi::{CStr},
-    path::PathBuf,
-};
-
-use libc::{c_char};
-
 use clap::{Args, Subcommand, ValueEnum};
 use katsuba_nav::{NavigationGraph, ZoneNavigationGraph};
 
 use super::Command;
-use crate::cli::{helpers, Bias, InputsOutputs, Processor, HYPHEN};
+use crate::cli::{helpers, Bias, InputsOutputs, Processor};
 
 /// Subcommand for working with NAV data.
 #[derive(Debug, Args)]
@@ -50,7 +43,7 @@ impl Command for Nav {
     }
 }
 
-fn deserialize_nav(args: InputsOutputs) -> eyre::Result<()> {
+pub fn deserialize_nav(args: InputsOutputs) -> eyre::Result<()> {
     let (inputs, outputs) = args.evaluate("de.json")?;
     Processor::new(Bias::Current)?
         .read_with(|r, _| NavigationGraph::parse(r).map_err(Into::into))
@@ -58,76 +51,10 @@ fn deserialize_nav(args: InputsOutputs) -> eyre::Result<()> {
         .process(inputs, outputs)
 }
 
-fn deserialize_zonenav(args: InputsOutputs) -> eyre::Result<()> {
+pub fn deserialize_zonenav(args: InputsOutputs) -> eyre::Result<()> {
     let (inputs, outputs) = args.evaluate("de.json")?;
     Processor::new(Bias::Current)?
         .read_with(|r, _| ZoneNavigationGraph::parse(r).map_err(Into::into))
         .write_with(helpers::write_as_json)
         .process(inputs, outputs)
-}
-
-#[no_mangle]
-pub extern "C" fn nav_deserialize(
-    input: *const c_char,
-    output: *const c_char,
-) -> bool {
-    let default_path = PathBuf::from(HYPHEN);
-
-    let rust_input = if input.is_null() {
-        return false
-    } else {
-        match unsafe { CStr::from_ptr(input) }.to_str() {
-            Ok(rust_str) => rust_str.to_owned(),
-            Err(_) => return false,
-        }
-    };
-
-    let rust_output = if output.is_null() {
-        default_path
-    } else {
-        match unsafe { CStr::from_ptr(output) }.to_str() {
-            Ok(rust_str) => PathBuf::from(rust_str),
-            Err(_) => default_path,
-        }
-    };
-
-    let io = InputsOutputs {
-        input: rust_input,
-        output: rust_output,
-    };
-
-    deserialize_nav(io).is_ok()
-}
-
-#[no_mangle]
-pub extern "C" fn zonenav_deserialize(
-    input: *const c_char,
-    output: *const c_char,
-) -> bool {
-    let default_path = PathBuf::from(HYPHEN);
-
-    let rust_input = if input.is_null() {
-        return false
-    } else {
-        match unsafe { CStr::from_ptr(input) }.to_str() {
-            Ok(rust_str) => rust_str.to_owned(),
-            Err(_) => return false,
-        }
-    };
-
-    let rust_output = if output.is_null() {
-        default_path
-    } else {
-        match unsafe { CStr::from_ptr(output) }.to_str() {
-            Ok(rust_str) => PathBuf::from(rust_str),
-            Err(_) => default_path,
-        }
-    };
-
-    let io = InputsOutputs {
-        input: rust_input,
-        output: rust_output,
-    };
-
-    deserialize_zonenav(io).is_ok()
 }

--- a/src/katsuba/src/cmd/nav.rs
+++ b/src/katsuba/src/cmd/nav.rs
@@ -1,8 +1,15 @@
+use std::{
+    ffi::{CStr},
+    path::PathBuf,
+};
+
+use libc::{c_char};
+
 use clap::{Args, Subcommand, ValueEnum};
 use katsuba_nav::{NavigationGraph, ZoneNavigationGraph};
 
 use super::Command;
-use crate::cli::{helpers, Bias, InputsOutputs, Processor};
+use crate::cli::{helpers, Bias, InputsOutputs, Processor, HYPHEN};
 
 /// Subcommand for working with NAV data.
 #[derive(Debug, Args)]
@@ -57,4 +64,70 @@ fn deserialize_zonenav(args: InputsOutputs) -> eyre::Result<()> {
         .read_with(|r, _| ZoneNavigationGraph::parse(r).map_err(Into::into))
         .write_with(helpers::write_as_json)
         .process(inputs, outputs)
+}
+
+#[no_mangle]
+pub extern "C" fn nav_deserialize(
+    input: *const c_char,
+    output: *const c_char,
+) -> bool {
+    let default_path = PathBuf::from(HYPHEN);
+
+    let rust_input = if input.is_null() {
+        return false
+    } else {
+        match unsafe { CStr::from_ptr(input) }.to_str() {
+            Ok(rust_str) => rust_str.to_owned(),
+            Err(_) => return false,
+        }
+    };
+
+    let rust_output = if output.is_null() {
+        default_path
+    } else {
+        match unsafe { CStr::from_ptr(output) }.to_str() {
+            Ok(rust_str) => PathBuf::from(rust_str),
+            Err(_) => default_path,
+        }
+    };
+
+    let io = InputsOutputs {
+        input: rust_input,
+        output: rust_output,
+    };
+
+    deserialize_nav(io).is_ok()
+}
+
+#[no_mangle]
+pub extern "C" fn zonenav_deserialize(
+    input: *const c_char,
+    output: *const c_char,
+) -> bool {
+    let default_path = PathBuf::from(HYPHEN);
+
+    let rust_input = if input.is_null() {
+        return false
+    } else {
+        match unsafe { CStr::from_ptr(input) }.to_str() {
+            Ok(rust_str) => rust_str.to_owned(),
+            Err(_) => return false,
+        }
+    };
+
+    let rust_output = if output.is_null() {
+        default_path
+    } else {
+        match unsafe { CStr::from_ptr(output) }.to_str() {
+            Ok(rust_str) => PathBuf::from(rust_str),
+            Err(_) => default_path,
+        }
+    };
+
+    let io = InputsOutputs {
+        input: rust_input,
+        output: rust_output,
+    };
+
+    deserialize_zonenav(io).is_ok()
 }

--- a/src/katsuba/src/cmd/op.rs
+++ b/src/katsuba/src/cmd/op.rs
@@ -1,11 +1,17 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{
+    ffi::CStr,
+    path::PathBuf,
+    sync::Arc
+};
+
+use libc::{c_char};
 
 use clap::{Args, Subcommand};
 use katsuba_object_property::serde::{self, SerializerOptions};
 use katsuba_types::{PropertyFlags, TypeList};
 
 use super::Command;
-use crate::cli::{helpers, Bias, InputsOutputs, Processor};
+use crate::cli::{helpers, Bias, InputsOutputs, Processor, HYPHEN};
 
 mod guess;
 mod utils;
@@ -165,4 +171,120 @@ fn deserialize(
         })
         .write_with(helpers::write_as_json)
         .process(inputs, outputs)
+}
+
+fn get_type_lists_from_c(type_lists: *const *const c_char) -> eyre::Result<Arc<TypeList>> {
+    let mut type_list_paths = Vec::new();
+    let mut i = 0;
+    loop {
+        let current_type_list = unsafe { *type_lists.add(i) };
+        if current_type_list.is_null() {
+            break // Null pointer indicates end of array
+        }
+
+        match unsafe { CStr::from_ptr(current_type_list) }.to_str() {
+            Ok(rust_str) => type_list_paths.push(PathBuf::from(rust_str)),
+            Err(_) => continue,
+        };
+
+        i += 1;
+    }
+
+    match utils::merge_type_lists(type_list_paths) {
+        Ok(combined_type_list) => Ok(Arc::new(combined_type_list)),
+        Err(report) => Err(report),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn op_deserialize(
+    input: *const c_char,
+    output: *const c_char,
+    type_lists: *const *const c_char,
+    flags: u32,
+    mask: u32,
+    shallow: bool,
+    manual_compression: bool,
+    djb2_only: bool,
+    ignore_unknown_types: bool,
+) -> bool {
+    let default_path = PathBuf::from(HYPHEN);
+
+    if input.is_null() || type_lists.is_null() {
+        return false
+    }
+
+    // Create the InputsOutputs
+    let rust_input = match unsafe { CStr::from_ptr(input) }.to_str() {
+        Ok(rust_str) => rust_str.to_owned(),
+        Err(_) => return false,
+    };
+
+    let rust_output = if output.is_null() {
+        default_path
+    } else {
+        match unsafe { CStr::from_ptr(output) }.to_str() {
+            Ok(rust_str) => PathBuf::from(rust_str),
+            Err(_) => default_path,
+        }
+    };
+
+    let io = InputsOutputs {
+        input: rust_input,
+        output: rust_output,
+    };
+
+    // Create the type_list
+    let type_list = match get_type_lists_from_c(type_lists) {
+        Ok(list) => list,
+        Err(_) => return false,
+    };
+
+    // Set the options
+    let options = serde::SerializerOptions {
+        flags: serde::SerializerFlags::from_bits_truncate(flags),
+        property_mask: PropertyFlags::from_bits_truncate(mask),
+        shallow: shallow,
+        manual_compression: manual_compression,
+        djb2_only: djb2_only,
+        ..Default::default()
+    };
+
+    deserialize(io, type_list, options, ignore_unknown_types).is_ok()
+}
+
+#[no_mangle]
+pub extern "C" fn op_guess(
+    path: *const c_char,
+    type_lists: *const *const c_char,
+    flags: u32,
+    mask: u32,
+    shallow: bool,
+    manual_compression: bool,
+    djb2_only: bool,
+    quiet: bool,
+) -> bool {
+
+    // Set the options
+    let options = serde::SerializerOptions {
+        flags: serde::SerializerFlags::from_bits_truncate(flags),
+        property_mask: PropertyFlags::from_bits_truncate(mask),
+        shallow: shallow,
+        manual_compression: manual_compression,
+        djb2_only: djb2_only,
+        ..Default::default()
+    };
+
+    // Create the type_list
+    let type_list = match get_type_lists_from_c(type_lists) {
+        Ok(list) => list,
+        Err(_) => return false,
+    };
+
+    let rust_path = match unsafe { CStr::from_ptr(path) }.to_str() {
+        Ok(rust_str) => PathBuf::from(rust_str),
+        Err(_) => return false,
+    };
+
+    guess::guess(options, type_list, rust_path, quiet).is_ok()
 }

--- a/src/katsuba/src/cmd/op.rs
+++ b/src/katsuba/src/cmd/op.rs
@@ -10,6 +10,9 @@ use crate::cli::{helpers, Bias, InputsOutputs, Processor};
 mod guess;
 mod utils;
 
+pub const DEFAULT_FLAGS: u32 = 0;
+pub const DEFAULT_MASK: u32 = 0x18;
+
 /// Subcommand for working with ObjectProperty serialization.
 #[derive(Debug, Args)]
 pub struct ObjectProperty {
@@ -33,7 +36,7 @@ pub struct ObjectProperty {
     /// instance and influence how data is interpreted.
     ///
     /// When in doubt what to pick, try 0 or using the guess command.
-    #[clap(short, long, default_value_t = 0)]
+    #[clap(short, long, default_value_t = DEFAULT_FLAGS)]
     flags: u32,
 
     /// Property filter mask to use.
@@ -42,7 +45,7 @@ pub struct ObjectProperty {
     /// of an object from the serialization.
     ///
     /// When in doubt what to pick, try the default value or 0.
-    #[clap(short, long, default_value_t = 0x18)]
+    #[clap(short, long, default_value_t = DEFAULT_MASK)]
     mask: u32,
 
     /// Whether the object is serialized shallow.

--- a/src/katsuba/src/cmd/op.rs
+++ b/src/katsuba/src/cmd/op.rs
@@ -1,20 +1,14 @@
-use std::{
-    ffi::CStr,
-    path::PathBuf,
-    sync::Arc
-};
-
-use libc::{c_char};
+use std::{path::PathBuf, sync::Arc};
 
 use clap::{Args, Subcommand};
-use katsuba_object_property::serde::{self, SerializerOptions};
+use katsuba_object_property::serde;
 use katsuba_types::{PropertyFlags, TypeList};
 
 use super::Command;
-use crate::cli::{helpers, Bias, InputsOutputs, Processor, HYPHEN};
+use crate::cli::{helpers, Bias, InputsOutputs, Processor};
 
-mod guess;
-mod utils;
+pub mod guess;
+pub mod utils;
 
 pub const DEFAULT_FLAGS: u32 = 0;
 pub const DEFAULT_MASK: u32 = 0x18;
@@ -141,10 +135,10 @@ impl Command for ObjectProperty {
     }
 }
 
-fn deserialize(
+pub fn deserialize(
     args: InputsOutputs,
     type_list: Arc<TypeList>,
-    mut options: SerializerOptions,
+    mut options: serde::SerializerOptions,
     ignore_unknown_types: bool,
 ) -> eyre::Result<()> {
     let (inputs, outputs) = args.evaluate("de.xml")?;
@@ -171,120 +165,4 @@ fn deserialize(
         })
         .write_with(helpers::write_as_json)
         .process(inputs, outputs)
-}
-
-fn get_type_lists_from_c(type_lists: *const *const c_char) -> eyre::Result<Arc<TypeList>> {
-    let mut type_list_paths = Vec::new();
-    let mut i = 0;
-    loop {
-        let current_type_list = unsafe { *type_lists.add(i) };
-        if current_type_list.is_null() {
-            break // Null pointer indicates end of array
-        }
-
-        match unsafe { CStr::from_ptr(current_type_list) }.to_str() {
-            Ok(rust_str) => type_list_paths.push(PathBuf::from(rust_str)),
-            Err(_) => continue,
-        };
-
-        i += 1;
-    }
-
-    match utils::merge_type_lists(type_list_paths) {
-        Ok(combined_type_list) => Ok(Arc::new(combined_type_list)),
-        Err(report) => Err(report),
-    }
-}
-
-#[no_mangle]
-pub extern "C" fn op_deserialize(
-    input: *const c_char,
-    output: *const c_char,
-    type_lists: *const *const c_char,
-    flags: u32,
-    mask: u32,
-    shallow: bool,
-    manual_compression: bool,
-    djb2_only: bool,
-    ignore_unknown_types: bool,
-) -> bool {
-    let default_path = PathBuf::from(HYPHEN);
-
-    if input.is_null() || type_lists.is_null() {
-        return false
-    }
-
-    // Create the InputsOutputs
-    let rust_input = match unsafe { CStr::from_ptr(input) }.to_str() {
-        Ok(rust_str) => rust_str.to_owned(),
-        Err(_) => return false,
-    };
-
-    let rust_output = if output.is_null() {
-        default_path
-    } else {
-        match unsafe { CStr::from_ptr(output) }.to_str() {
-            Ok(rust_str) => PathBuf::from(rust_str),
-            Err(_) => default_path,
-        }
-    };
-
-    let io = InputsOutputs {
-        input: rust_input,
-        output: rust_output,
-    };
-
-    // Create the type_list
-    let type_list = match get_type_lists_from_c(type_lists) {
-        Ok(list) => list,
-        Err(_) => return false,
-    };
-
-    // Set the options
-    let options = serde::SerializerOptions {
-        flags: serde::SerializerFlags::from_bits_truncate(flags),
-        property_mask: PropertyFlags::from_bits_truncate(mask),
-        shallow: shallow,
-        manual_compression: manual_compression,
-        djb2_only: djb2_only,
-        ..Default::default()
-    };
-
-    deserialize(io, type_list, options, ignore_unknown_types).is_ok()
-}
-
-#[no_mangle]
-pub extern "C" fn op_guess(
-    path: *const c_char,
-    type_lists: *const *const c_char,
-    flags: u32,
-    mask: u32,
-    shallow: bool,
-    manual_compression: bool,
-    djb2_only: bool,
-    quiet: bool,
-) -> bool {
-
-    // Set the options
-    let options = serde::SerializerOptions {
-        flags: serde::SerializerFlags::from_bits_truncate(flags),
-        property_mask: PropertyFlags::from_bits_truncate(mask),
-        shallow: shallow,
-        manual_compression: manual_compression,
-        djb2_only: djb2_only,
-        ..Default::default()
-    };
-
-    // Create the type_list
-    let type_list = match get_type_lists_from_c(type_lists) {
-        Ok(list) => list,
-        Err(_) => return false,
-    };
-
-    let rust_path = match unsafe { CStr::from_ptr(path) }.to_str() {
-        Ok(rust_str) => PathBuf::from(rust_str),
-        Err(_) => return false,
-    };
-
-    guess::guess(options, type_list, rust_path, quiet).is_ok()
 }

--- a/src/katsuba/src/cmd/poi.rs
+++ b/src/katsuba/src/cmd/poi.rs
@@ -21,12 +21,16 @@ impl Command for Poi {
     fn handle(self) -> eyre::Result<()> {
         match self.command {
             PoiCommand::De(args) => {
-                let (inputs, outputs) = args.evaluate("de.json")?;
-                Processor::new(Bias::Current)?
-                    .read_with(|r, _| PoiFile::parse(r).map_err(Into::into))
-                    .write_with(helpers::write_as_json)
-                    .process(inputs, outputs)
+                return deserialize(args)
             }
         }
     }
+}
+
+fn deserialize(args: InputsOutputs) -> eyre::Result<()> {
+    let (inputs, outputs) = args.evaluate("de.json")?;
+    Processor::new(Bias::Current)?
+        .read_with(|r, _| PoiFile::parse(r).map_err(Into::into))
+        .write_with(helpers::write_as_json)
+        .process(inputs, outputs)
 }

--- a/src/katsuba/src/cmd/poi.rs
+++ b/src/katsuba/src/cmd/poi.rs
@@ -1,15 +1,8 @@
-use std::{
-    ffi::{CStr},
-    path::{PathBuf},
-};
-
-use libc::{c_char};
-
 use clap::{Args, Subcommand};
 use katsuba_poi::Poi as PoiFile;
 
 use super::Command;
-use crate::cli::{helpers, Bias, InputsOutputs, Processor, HYPHEN};
+use crate::cli::{helpers, Bias, InputsOutputs, Processor};
 
 /// Subcommand for working with POI data.
 #[derive(Debug, Args)]
@@ -34,43 +27,10 @@ impl Command for Poi {
     }
 }
 
-fn deserialize(args: InputsOutputs) -> eyre::Result<()> {
+pub fn deserialize(args: InputsOutputs) -> eyre::Result<()> {
     let (inputs, outputs) = args.evaluate("de.json")?;
     Processor::new(Bias::Current)?
         .read_with(|r, _| PoiFile::parse(r).map_err(Into::into))
         .write_with(helpers::write_as_json)
         .process(inputs, outputs)
-}
-
-#[no_mangle]
-pub extern "C" fn poi_deserialize(
-    input: *const c_char,
-    output: *const c_char,
-) -> bool {
-    let default_path = PathBuf::from(HYPHEN);
-
-    let rust_input = if input.is_null() {
-        return false
-    } else {
-        match unsafe { CStr::from_ptr(input) }.to_str() {
-            Ok(rust_str) => rust_str.to_owned(),
-            Err(_) => return false,
-        }
-    };
-
-    let rust_output = if output.is_null() {
-        default_path
-    } else {
-        match unsafe { CStr::from_ptr(output) }.to_str() {
-            Ok(rust_str) => PathBuf::from(rust_str),
-            Err(_) => default_path,
-        }
-    };
-
-    let io = InputsOutputs {
-        input: rust_input,
-        output: rust_output,
-    };
-
-    deserialize(io).is_ok()
 }

--- a/src/katsuba/src/cmd/poi.rs
+++ b/src/katsuba/src/cmd/poi.rs
@@ -1,8 +1,15 @@
+use std::{
+    ffi::{CStr},
+    path::{PathBuf},
+};
+
+use libc::{c_char};
+
 use clap::{Args, Subcommand};
 use katsuba_poi::Poi as PoiFile;
 
 use super::Command;
-use crate::cli::{helpers, Bias, InputsOutputs, Processor};
+use crate::cli::{helpers, Bias, InputsOutputs, Processor, HYPHEN};
 
 /// Subcommand for working with POI data.
 #[derive(Debug, Args)]
@@ -33,4 +40,37 @@ fn deserialize(args: InputsOutputs) -> eyre::Result<()> {
         .read_with(|r, _| PoiFile::parse(r).map_err(Into::into))
         .write_with(helpers::write_as_json)
         .process(inputs, outputs)
+}
+
+#[no_mangle]
+pub extern "C" fn poi_deserialize(
+    input: *const c_char,
+    output: *const c_char,
+) -> bool {
+    let default_path = PathBuf::from(HYPHEN);
+
+    let rust_input = if input.is_null() {
+        return false
+    } else {
+        match unsafe { CStr::from_ptr(input) }.to_str() {
+            Ok(rust_str) => rust_str.to_owned(),
+            Err(_) => return false,
+        }
+    };
+
+    let rust_output = if output.is_null() {
+        default_path
+    } else {
+        match unsafe { CStr::from_ptr(output) }.to_str() {
+            Ok(rust_str) => PathBuf::from(rust_str),
+            Err(_) => default_path,
+        }
+    };
+
+    let io = InputsOutputs {
+        input: rust_input,
+        output: rust_output,
+    };
+
+    deserialize(io).is_ok()
 }

--- a/src/katsuba/src/cmd/wad.rs
+++ b/src/katsuba/src/cmd/wad.rs
@@ -15,6 +15,8 @@ use crate::cli::{Bias, InputsOutputs, Processor, Reader, HYPHEN};
 
 mod extract;
 
+pub const DEFAULT_FLAGS: u8 = 0;
+
 /// Subcommand for working with KIWAD archives.
 #[derive(Debug, Args)]
 pub struct Wad {
@@ -41,7 +43,7 @@ enum WadCommand {
         /// is generally not recommended. The only exception to that
         /// rule is when repacking Root.wad, in which case a value of
         /// 1 must be set.
-        #[clap(short, default_value_t = 0)]
+        #[clap(short, default_value_t = DEFAULT_FLAGS)]
         flags: u8,
 
         /// The optional output file to write the archive to.

--- a/src/katsuba/src/lib.rs
+++ b/src/katsuba/src/lib.rs
@@ -1,0 +1,5 @@
+
+pub mod cli;
+pub mod cmd;
+mod utils;
+


### PR DESCRIPTION
This PR adds a new crate to katsuba called `katsuba-c`. It allows C programs to link with the compiled .dll `katsubac` to call any CLI command function.

### Changes
- Created a `katsuba-c` crate for providing C linkage.
- Moved all CLI `cmd` logic out of the match expressions and into separate public functions. These functions are public so the new `katsuba-c` crate can call them.
- Some types, such as the fields of `katsuba::cli::io::InputsOutputs`, were marked public to be accessible from the new crate.
- Some default values for CLI options were moved to public module variables, such as the environment variable name for the client signature private key (`KATSUBA_CLIENTSIG_PRIVATE_KEY`).

Frankly, I do not know what all of the options in the CLI do. I only tested and ensured that I could call the `katsuba wad` and `katsuba op` functions properly from the CLI and from another C program. If this PR is deemed risky, feel free to decline it and I will use this branch for my own purposes.